### PR TITLE
fix: fixed check if go.mod or go.sum are unstaged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,9 +44,13 @@ jobs:
         run: |
           go mod tidy
 
-          git add go.mod go.sum
-          git commit -m "Update go.mod go.sum [skip ci]"
-          git push
+          status=$(git status go.mod go.sum --porcelain)
+
+          if [ -n "$status" ]; then
+            git add go.mod go.sum
+            git commit -m "Update go.mod go.sum [skip ci]"
+            git push
+          fi
 
       - name: Update version
         run: |


### PR DESCRIPTION
This PR is adding a check, whether to commit `go.mod` or `go.sum` after running `go mod tidy` in the `release` workflow. Otherwise, the workflow would produce an empty commit and therefore exit with a status > 0.